### PR TITLE
Updated cogs.rb to match new Guard 2.x syntax

### DIFF
--- a/lib/guard/cogs.rb
+++ b/lib/guard/cogs.rb
@@ -1,11 +1,11 @@
 require 'guard'
-require 'guard/guard'
+require 'guard/plugin'
 require 'sprockets'
 
 module Guard
-  class Cogs < Guard
+  class Cogs < Plugin
 
-    def initialize(watchers = [], options = {})
+    def initialize(options = {})
       super
 
       @compile = options[:compile]


### PR DESCRIPTION
As mentioned here: https://github.com/guard/guard/wiki/Upgrading-to-Guard-2.0#guardguard-deprecated-in-favor-of-guardplugin

> To remove the confusion between Guard and its many plugins (guard-rspec, guard-pow, guard-livereload etc.), `Guard::Guard` is renamed `Guard::Plugin`. `Guard::Guard` is deprecated so if you're a plugin maintainer, in your next (major) release **that will depend on Guard ~> 2.0** you must make your plugin inherit from `Guard::Plugin` instead of `Guard::Guard`.
> 
> Also, please be sure to change the `#initialize` signature from `#initialize(watchers = [], options = {})` to `#initialize(options = {})` (watchers are now passed in the `options` argument directly).
